### PR TITLE
Add support for BE machines + bugfixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -16,14 +16,14 @@ void DSPEncodeFrame(short* source, int samples, unsigned char* dest, short* coef
 #define PACKET_SAMPLES 14
 #define PACKET_BYTES 8
 
-#ifdef __linux__
-#define ALSA_PLAY 1
-#endif
 #if ALSA_PLAY
 #include <alsa/asoundlib.h>
 snd_pcm_t* ALSA_PCM;
 #endif
+
+#ifdef WRITE_WAV
 FILE* WAVE_FILE_OUT = NULL;
+#endif
 
 /* Standard DSPADPCM header */
 struct dspadpcm_header
@@ -84,16 +84,15 @@ int main(int argc, char** argv)
 
     if (argc < 3)
     {
-        printf("Usage: dspenc <wavin> <dspout>\n");
-        return 0;
+        printf("Usage: %s <wavin> <dspout>\n", *argv);
+        return 1;
     }
 
     FILE* fin = fopen(argv[1], "rb");
     if (!fin)
     {
         fprintf(stderr, "'%s' won't open - %s\n", argv[1], strerror(errno));
-        fclose(fin);
-        return -1;
+        return 1;
     }
     char riffcheck[4];
     fread(riffcheck, 1, 4, fin);
@@ -101,7 +100,7 @@ int main(int argc, char** argv)
     {
         fprintf(stderr, "'%s' not a valid RIFF file\n", argv[1]);
         fclose(fin);
-        return -1;
+        return 1;
     }
     fseek(fin, 4, SEEK_CUR);
     fread(riffcheck, 1, 4, fin);
@@ -109,7 +108,7 @@ int main(int argc, char** argv)
     {
         fprintf(stderr, "'%s' not a valid WAVE file\n", argv[1]);
         fclose(fin);
-        return -1;
+        return 1;
     }
 
     uint32_t samplerate = 0;
@@ -118,45 +117,63 @@ int main(int argc, char** argv)
     {
         uint32_t chunkSz;
         fread(&chunkSz, 1, 4, fin);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        chunkSz = __builtin_bswap32(chunkSz);
+#endif
         if (!memcmp(riffcheck, "fmt ", 4))
         {
             uint16_t fmt;
             fread(&fmt, 1, 2, fin);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            fmt = __builtin_bswap16(fmt);
+#endif
             if (fmt != 1)
             {
                 fprintf(stderr, "'%s' has invalid format %u\n", argv[1], fmt);
                 fclose(fin);
-                return -1;
+                return 1;
             }
 
             uint16_t nchan;
             fread(&nchan, 1, 2, fin);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            nchan = __builtin_bswap16(nchan);
+#endif
             if (nchan != 1)
             {
                 fprintf(stderr, "'%s' must have 1 channel, not %u\n", argv[1], nchan);
                 fclose(fin);
-                return -1;
+                return 1;
             }
 
             fread(&samplerate, 1, 4, fin);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            samplerate = __builtin_bswap32(samplerate);
+#endif
             fseek(fin, 4, SEEK_CUR);
 
             uint16_t bytesPerSample;
             fread(&bytesPerSample, 1, 2, fin);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            bytesPerSample = __builtin_bswap16(bytesPerSample);
+#endif
             if (bytesPerSample != 2)
             {
                 fprintf(stderr, "'%s' must have 2 bytes per sample, not %u\n", argv[1], bytesPerSample);
                 fclose(fin);
-                return -1;
+                return 1;
             }
 
             uint16_t bitsPerSample;
             fread(&bitsPerSample, 1, 2, fin);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            bitsPerSample = __builtin_bswap16(bitsPerSample);
+#endif
             if (bitsPerSample != 16)
             {
                 fprintf(stderr, "'%s' must have 16 bits per sample, not %u\n", argv[1], bitsPerSample);
                 fclose(fin);
-                return -1;
+                return 1;
             }
         }
         else if (!memcmp(riffcheck, "data", 4))
@@ -172,7 +189,7 @@ int main(int argc, char** argv)
     {
         fprintf(stderr, "'%s' must have a valid data chunk following a fmt chunk\n", argv[1]);
         fclose(fin);
-        return -1;
+        return 1;
     }
 
 #if ALSA_PLAY
@@ -181,20 +198,30 @@ int main(int argc, char** argv)
     snd_pcm_hw_params_alloca(&hwparams);
     snd_pcm_hw_params_any(ALSA_PCM, hwparams);
     snd_pcm_hw_params_set_access(ALSA_PCM, hwparams, SND_PCM_ACCESS_RW_INTERLEAVED);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    snd_pcm_hw_params_set_format(ALSA_PCM, hwparams, SND_PCM_FORMAT_S16_BE);
+#else
     snd_pcm_hw_params_set_format(ALSA_PCM, hwparams, SND_PCM_FORMAT_S16_LE);
+#endif
     unsigned int sample_rate = samplerate;
     snd_pcm_hw_params_set_rate_near(ALSA_PCM, hwparams, &sample_rate, 0);
     snd_pcm_hw_params_set_channels(ALSA_PCM, hwparams, 1);
     snd_pcm_hw_params(ALSA_PCM, hwparams);
 #endif
 
+#ifdef WRITE_WAV
     char wavePathOut[1024];
     snprintf(wavePathOut, 1024, "%s.wav", argv[2]);
     WAVE_FILE_OUT = fopen(wavePathOut, "wb");
+    if (!WAVE_FILE_OUT)
+    {
+        fprintf(stderr, "'%s' won't open - %s\n", wavePathOut, strerror(errno));
+        fclose(fin);
+        return 1;
+    }
     for (i=0 ; i<11 ; ++i)
         fwrite("\0\0\0\0", 1, 4, WAVE_FILE_OUT);
-
-    printf("\e[?25l"); /* hide the cursor */
+#endif
 
     int packetCount = samplecount / PACKET_SAMPLES + (samplecount % PACKET_SAMPLES != 0);
     size_t sampsBufSz = samplecount * 2;
@@ -203,12 +230,32 @@ int main(int argc, char** argv)
     fread(sampsBuf, samplecount, 2, fin);
     fclose(fin);
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    for(i = 0; i < samplecount; i++)
+        sampsBuf[i] = __builtin_bswap16(sampsBuf[i]);
+#endif
+
     int16_t coefs[16];
     DSPCorrelateCoefs(sampsBuf, samplecount, coefs);
 
     /* Open output file */
     FILE* fout = fopen(argv[2], "wb");
+    if (!fout)
+    {
+        fprintf(stderr, "'%s' won't open - %s\n", argv[2], strerror(errno));
+        return 1;
+    }
     struct dspadpcm_header header = {};
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    header.num_samples = samplecount;
+    header.num_nibbles = GetNibbleFromSample(samplecount);
+    header.sample_rate = samplerate;
+    header.loop_start = GetNibbleAddress(0);
+    header.loop_end = GetNibbleAddress(samplecount - 1);
+    header.ca = GetNibbleAddress(0);
+    for (i=0 ; i<16 ; ++i)
+        header.coef[i] = coefs[i];
+#else
     header.num_samples = __builtin_bswap32(samplecount);
     header.num_nibbles = __builtin_bswap32(GetNibbleFromSample(samplecount));
     header.sample_rate = __builtin_bswap32(samplerate);
@@ -217,6 +264,9 @@ int main(int argc, char** argv)
     header.ca = __builtin_bswap32(GetNibbleAddress(0));
     for (i=0 ; i<16 ; ++i)
         header.coef[i] = __builtin_bswap16(coefs[i]);
+#endif
+
+    printf("\e[?25l"); /* hide the cursor */
 
     /* Execute encoding-predictor for each block */
     int16_t convSamps[16] = {0};
@@ -234,14 +284,20 @@ int main(int argc, char** argv)
 #if ALSA_PLAY
         snd_pcm_writei(ALSA_PCM, convSamps+2, PACKET_SAMPLES);
 #endif
+#ifdef WRITE_WAV
         fwrite(convSamps+2, 2, PACKET_SAMPLES, WAVE_FILE_OUT);
+#endif
 
         convSamps[0] = convSamps[14];
         convSamps[1] = convSamps[15];
         
         if (p == 0)
         {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            header.ps = block[0];
+#else
             header.ps = __builtin_bswap16(block[0]);
+#endif
             fwrite(&header, 1, sizeof(header), fout);
         }
 
@@ -256,6 +312,7 @@ int main(int argc, char** argv)
 
     //printf("ERROR: %ld\n", ERROR_AVG / ERROR_SAMP_COUNT);
 
+#ifdef WRITE_WAV
     uint32_t totalSz = ftell(WAVE_FILE_OUT) - 8;
     fseek(WAVE_FILE_OUT, 0, SEEK_SET);
     fwrite("RIFF", 1, 4, WAVE_FILE_OUT);
@@ -279,6 +336,7 @@ int main(int argc, char** argv)
     totalSz -= 36;
     fwrite(&totalSz, 1, 4, WAVE_FILE_OUT);
     fclose(WAVE_FILE_OUT);
+#endif
 
     fclose(fout);
     free(sampsBuf);


### PR DESCRIPTION
- Add support for big endian machines (e.g. PPC hosts)
- Fix free bugs (`fclose()` after the file was closed/if it was not yet opened)
- Disable creation of WAVE_FILE_OUT by default (can be enabled by defining `WRITE_WAV`)
- Disable ALSA code by default (can be enabled with `ALSA_PLAY`)
- Fix status codes (`0` on success, `1` on error)
- Fix show/hide of cursor in (most?) error cases